### PR TITLE
inotify: fix event filter to handle file writing and file renames

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -83,7 +83,7 @@ async fn main() -> anyhow::Result<()> {
     let meta = args.meta.clone();
     tokio::spawn(async move {
       let inotify = Inotify::init()?;
-      inotify.watches().add(meta, WatchMask::MODIFY)?;
+      inotify.watches().add(meta, WatchMask::CLOSE_WRITE | WatchMask::MOVED_TO)?;
       let mut buf = [0; 1024];
       let mut stream = inotify.into_event_stream(&mut buf)?;
 


### PR DESCRIPTION
The inotify event `MODIFY` does trigger on writes and truncates but we only wan't to be triggered after the files has been completely written **or** when it was target of a rename (`MOVED_TO`).